### PR TITLE
swagger.json 导入报错： Excetion evaluating SoringEL expression: "table.mo…

### DIFF
--- a/src/main/java/org/word/parser/impl/SwaggerDataV2Parser.java
+++ b/src/main/java/org/word/parser/impl/SwaggerDataV2Parser.java
@@ -68,7 +68,7 @@ public class SwaggerDataV2Parser extends AbsSwaggerDataParser {
         if (obj != null && obj.get("schema") != null) {
             return processResponseModelAttrs(obj, definitinMap);
         }
-        return null;
+        return new ModelAttr();
     }
 
 


### PR DESCRIPTION
swagger.json 导入报错，原因是有接口返回值为 void，导致 ModelAttr 为 null